### PR TITLE
Delete task outside of critical section to avoid malloc mutex deadlock

### DIFF
--- a/FreeRTOS/Source/tasks.c
+++ b/FreeRTOS/Source/tasks.c
@@ -1216,20 +1216,24 @@ static void prvAddNewTaskToReadyList( TCB_t *pxNewTCB )
 				hence xYieldPending is used to latch that a context switch is
 				required. */
 				portPRE_TASK_DELETE_HOOK( pxTCB, &xYieldPending );
+				traceTASK_DELETE( pxTCB );
 			}
 			else
 			{
 				--uxCurrentNumberOfTasks;
-				prvDeleteTCB( pxTCB );
 
 				/* Reset the next expected unblock time in case it referred to
 				the task that has just been deleted. */
 				prvResetNextTaskUnblockTime();
 			}
+		}
 
+		taskEXIT_CRITICAL();
+		if ( pxTCB != pxCurrentTCB )
+		{
+			prvDeleteTCB( pxTCB );
 			traceTASK_DELETE( pxTCB );
 		}
-		taskEXIT_CRITICAL();
 
 		/* Force a reschedule if it is the currently running task that has just
 		been deleted. */


### PR DESCRIPTION
During USB de-initialization, the realtek SDK will delete its internal USB Freertos task. This process involves freeing malloc'd memory. Our heap implementation is protected by a mutex, which can be unavailable if another task holds the mutex. 
The default implementation of `vTaskDelete()` in freertos deletes all tasks under a critical section, ie with interrupts disabled.
If we call `vTaskDelete()` while another task holds the malloc mutex, we will deadlock as interrupts are disabled. 
This PR moves the actual tcb deletion / freeing outside of the critical section in order to avoid deadlocks on this mutex. 

See original discussion [here](https://s.slack.com/archives/C0521QM1P5Z/p1681936014504329?thread_ts=1681763876.576239&cid=C0521QM1P5Z)

Credit to @avtolstoy for the fix.